### PR TITLE
樹種別齢級別面積データ(xls)をダウンロード

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 .env
+*.xls

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,6 @@ RUN set -x && \
     ensurer \
     here \
     styler && \
+  installGithub.r \
+    "uribo/odkitchen" && \
   rm -rf /tmp/downloaded_packages/ /tmp/*.rds

--- a/data-raw/download_genkyo.R
+++ b/data-raw/download_genkyo.R
@@ -49,5 +49,15 @@ if (length(fs::dir_ls(here::here("data-raw"), regexp = "genkyo_[0-9]{4}.xls")) !
         xml2::url_absolute(.x)) %>%
     ensure(length(.) == 3L)
 
-  # [TODO] 2/2 data-rawフォルダにダウンロード ------------------------------
+  # 2/2 data-rawフォルダにダウンロード ------------------------------
+  dl_links %>%
+    walk2(
+      .y = names(dl_links),
+      .f = ~
+        curl::curl_download(.x,
+                            destfile = glue::glue("data-raw/genkyo_{year}.",
+                                                  # ファイル形式を取得 hoge.xls --> xls
+                                                  tools::file_ext(.x),
+                                                  # 和暦から西暦へ H29 --> 2017
+                                                  year = odkitchen::convert_jyr(.y))))
 }


### PR DESCRIPTION
## Summary

林野庁の統計情報から[森林資源の現況](http://www.rinya.maff.go.jp/j/keikaku/genkyou/index1.html)  樹種別齢級別面積データ（`.xls`, 3年分）をダウンロードする処理。
ダウンロードしたファイルは`data-raw`に保存。和暦だとわかりにくいのでファイル名には西暦に変換したものを採用した。

`.xls`はバイナリファイルのためリポジトリには含めない。

```r
fs::dir_ls(here::here("data-raw"), regexp = "genkyo_[0-9]{4}.xls")
# /home/rstudio/maff_forest_stats/data-raw/genkyo_2007.xls 
# /home/rstudio/maff_forest_stats/data-raw/genkyo_2012.xls 
# /home/rstudio/maff_forest_stats/data-raw/genkyo_2017.xls 
```

## Related issues

なし